### PR TITLE
Update slf4j to work with Timber v3.+

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ Download [the latest JAR][4] or grab via Maven:
 <dependency>
   <groupId>com.arcao</groupId>
   <artifactId>slf4j-timber</artifactId>
-  <version>1.5</version>
+  <version>2.0-SNAPSHOT</version>
 </dependency>
 ```
 or Gradle:
 ```groovy
-compile 'com.arcao:slf4j-timber:1.+'
+compile 'com.arcao:slf4j-timber:2.+'
 ```
 
 > Note: `timber` and `slf4j-api` are the transitive dependencies of `slf4j-timber`, 
@@ -62,13 +62,13 @@ Maven:
 <dependency>
   <groupId>com.arcao</groupId>
   <artifactId>slf4j-timber</artifactId>
-  <version>1.5</version>
+  <version>2.0-SNAPSHOT</version>
 </dependency>
 ```
 or Gradle:
 ```groovy
 compile 'org.slf4j:log4j-over-slf4j:1.7.7'
-compile 'com.arcao:slf4j-timber:1.+'
+compile 'com.arcao:slf4j-timber:2.+'
 ```
 
 Don't forget to exclude `log4j` transitive dependency from artifact which use 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 	
 	<groupId>com.arcao</groupId>
 	<artifactId>slf4j-timber</artifactId>
-	<version>1.6-SNAPSHOT</version>
+	<version>2.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
 	<name>slf4j-timber</name>
@@ -37,7 +37,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<java.version>1.6</java.version>
 		<slf4j.version>1.7.7</slf4j.version>
-		<timber.version>2.5.1</timber.version>
+		<timber.version>3.0.1</timber.version>
 		<android.version>4.1.1.4</android.version>
 		<android.platform>16</android.platform>
 		<junit.version>4.10</junit.version>

--- a/src/test/java/com/arcao/slf4j/timber/TimberLoggerAdapterTest.java
+++ b/src/test/java/com/arcao/slf4j/timber/TimberLoggerAdapterTest.java
@@ -16,7 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import timber.log.Timber;
-import timber.log.TimberTestHelper;
 import android.util.Log;
 
 @RunWith(RobolectricTestRunner.class)
@@ -25,7 +24,7 @@ public class TimberLoggerAdapterTest {
   private static final Logger logger = LoggerFactory.getLogger(TimberLoggerAdapterTest.class);
 
   @Before @After public void setUpAndTearDown() {
-    TimberTestHelper.cleanTimber();
+    Timber.uprootAll();
   }
 
   @Test public void debugTest() {

--- a/src/test/java/timber/log/TimberTestHelper.java
+++ b/src/test/java/timber/log/TimberTestHelper.java
@@ -1,8 +1,0 @@
-package timber.log;
-
-public final class TimberTestHelper {
-  public static void cleanTimber() {
-    Timber.FOREST.clear();
-    Timber.TAGGED_TREES.clear();
-  }
-}


### PR DESCRIPTION
Unfortunately since Timber.Tree has changed from interface to abstract class
I can't see any way of doing this in a backwards compatible manner.
For that reason I bumped major version.

Might want to split it into two artifacts one supporting timber 2.+ and one supporting 3.+
